### PR TITLE
Change the order of function tracing for saved model.

### DIFF
--- a/keras/saving/legacy/saved_model/save_impl.py
+++ b/keras/saving/legacy/saved_model/save_impl.py
@@ -384,7 +384,7 @@ def tracing_scope():
     finally:
         # Run traces from the queue.
         while _thread_local_data.trace_queue:
-            fn, args, kwargs, training = _thread_local_data.trace_queue.pop()
+            fn, args, kwargs, training = _thread_local_data.trace_queue.pop(0)
             if training is not None:
                 with backend.deprecated_internal_learning_phase_scope(training):
                     fn.get_concrete_function(*args, **kwargs)


### PR DESCRIPTION
Since the dropout layer and other layers that uses RNG will create the variable when training=True, if user code branched based on that, the current order will raise an error from tf.function about creating variable in non-first call.

Change to trace the training=True function first to avoid this potential issue.

PiperOrigin-RevId: 488663939