### PR TITLE
Set `jit_compile` only when TensorFlow XLA is available for the platf…

### DIFF
--- a/keras/optimizers/optimizer.py
+++ b/keras/optimizers/optimizer.py
@@ -53,10 +53,15 @@ class _BaseOptimizer(tf.__internal__.tracking.AutoTrackable):
         self.global_clipnorm = global_clipnorm
         self.clipvalue = clipvalue
         self.use_ema = use_ema
-        self.jit_compile = jit_compile
-        if not tf.config.list_physical_devices("GPU"):
-            # Optimizer only benefits from XLA when training on GPU. So if no
-            # GPU is found, we turn off XLA.
+        # Optimizer only benefits from XLA when training on GPU. So if no
+        # GPU is found, we turn off XLA.
+        if (
+            jit_compile
+            and tf_utils.can_jit_compile()
+            and tf.config.list_physical_devices("GPU")
+        ):
+            self.jit_compile = True
+        else:
             self.jit_compile = False
         if use_ema:
             # Verify the arguments related to EMA.

--- a/keras/utils/tf_utils.py
+++ b/keras/utils/tf_utils.py
@@ -16,10 +16,12 @@
 
 import collections
 import copy
+import platform
 import random
 
 import numpy as np
 import tensorflow.compat.v2 as tf
+from absl import logging
 
 from keras import backend
 from keras.engine import keras_tensor
@@ -675,3 +677,15 @@ def _astuple(attrs):
     for field in fields:
         values.append(getattr(attrs, field.name))
     return tuple(values)
+
+
+def can_jit_compile(warn=False):
+    """Returns True if TensorFlow XLA is available for the platform."""
+    if platform.system() == "Darwin" and "arm" in platform.processor().lower():
+        if warn:
+            logging.warning(
+                "Tensorflow is not compiled with XLA on Mac M1 Arm processors, "
+                "so cannot set `jit_compile` to True."
+            )
+        return False
+    return True

--- a/keras/utils/tf_utils_test.py
+++ b/keras/utils/tf_utils_test.py
@@ -14,6 +14,9 @@
 # ==============================================================================
 """Tests for Keras TF utils."""
 
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import numpy as np
 import tensorflow.compat.v2 as tf
 from absl.testing import parameterized
@@ -468,6 +471,17 @@ class TestSyncToNumpyOrPythonType(parameterized.TestCase):
         tensor = tf.constant(value)
 
         self.assertEqual(tf_utils.sync_to_numpy_or_python_type(tensor), value)
+
+
+class TestCanJitCompile(tf.test.TestCase):
+    def test_darwin_arm_xla(self):
+        with patch("platform.processor", MagicMock(return_value="arm")):
+            with patch("platform.system", MagicMock(return_value="Darwin")):
+                self.assertFalse(tf_utils.can_jit_compile())
+
+    def test_linux_xla(self):
+        with patch("platform.system", MagicMock(return_value="Linux")):
+            self.assertTrue(tf_utils.can_jit_compile())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…orm.

Fixes issue of using new optimizers on Mac M1 as TF on Mac M1 is not built with XLA.

PiperOrigin-RevId: 497158007